### PR TITLE
Update location of library dependencies; add download helper script

### DIFF
--- a/README.build
+++ b/README.build
@@ -25,7 +25,7 @@ To build Kleene from source on Linux:
 1.  See README.git to clone a copy of the kleene-lang/ directory from
 Github.
 
-2.  Once you have the downloaded the source code, there are also some
+2a.  Once you have the downloaded the source code, there are also some
 external libraries that need to be downloaded separately.  cd to the
 tools/ directory
 
@@ -39,6 +39,12 @@ directory as the kleene-lang directory.  Then in kleene-lang/tools/
 enter the command
 
 $ make links
+
+2b. Alternatively, you can try to grab the dependencies directly from
+their sources on the internet and rebuild them from scratch:
+
+$ cd kleene-lang/tools
+$ ./download.sh
 
 3.  To build Kleene on Linux you will need the g++ compiler.  Install it if
 necessary.

--- a/tools/ICU4C/Makefile
+++ b/tools/ICU4C/Makefile
@@ -27,7 +27,7 @@ ICU4C_LIB_DIR=$(ICU4C_SOURCE_DIR)/lib
 # a number of libraries are compiled, including libicudata
 ICU4C_LIB_BASENAME=libicudata
 # this is the naming-convention format for the compiled libraries
-ICU4C_LIB_VERSION=51.1
+ICU4C_LIB_VERSION=54.1
 
 # different operating systems use different extensions
 # for the compiled libraries

--- a/tools/ICU4C/README
+++ b/tools/ICU4C/README
@@ -2,7 +2,7 @@ ICU4C
 
 To be built from source, Kleene needs
 
-icu4c-51_1-src.tgz
+icu4c-54_1-src.tgz
 
 For license information, see kleene-lang/NOTICE.
 
@@ -12,13 +12,16 @@ kleene-lang/tools/README
 ***** lines below are notes, not instructions
 
 If the easy way it not possible or convenient
-you need to download icu4c-51_1-src.tgz
+you need to download icu4c-54_1-src.tgz
 from
 	http://site.icu-project.org/download
 to
 	kleene-lang/tools/ICU4C/
 
 
+
+2018-10-24
+	needs icu4c-54_1-src.tgs
 
 2013-05-05
 	needs icu4c-51_1-src.tgs

--- a/tools/ICU4J/README
+++ b/tools/ICU4J/README
@@ -1,6 +1,6 @@
 ICU4J
 
-To compile Kleene from source, you need icu4j-51_1.jar
+To compile Kleene from source, you need icu4j-54_1_1.jar
 
 For license information, see kleene-lang/NOTICE.
 
@@ -10,7 +10,7 @@ available to Kleene, see kleene-lang/tools/README
 ***** lines below are notes, not instructions
 
 If the easy way is not possible or convenient, you will
-need to download icu4j-51_1.jar from
+need to download icu4j-54_1_1.jar from
 
 from
 	http://site.icu-project.org/download
@@ -18,6 +18,9 @@ to
 	kleene-lang/tools/ICU4J/
 
 
+
+2018-10-24
+	use icu4j-54_1_1.jar
 
 2013-05-05
 	use icu4j-51_1.jar

--- a/tools/JavaCC/README
+++ b/tools/JavaCC/README
@@ -14,7 +14,7 @@ For the easy way to install it, see kleene-lang/tools/README
 If the easy way is not possible or convenient, you
 need to download javacc-5.0.tar.gz
 
-from:   http://java.net/projects/javacc/downloads
+from:   https://javacc.org/download
 
 to:     tools/JavaCC/
 

--- a/tools/Jaxen/README
+++ b/tools/Jaxen/README
@@ -11,12 +11,15 @@ to Kleene, see kleene-lang/tools/README
 
 If the easy way is not possible or appropriate you will
 need to download jaxen-1.1.6-bin.tar.gz from
- 	http://jaxen.codehaus.org/releases.html
+	http://www.cafeconleche.org/jaxen/
 into 	
 	kleene-lang/tools/Jaxen/
 
 jaxen-1.1.6-bin.tar.gz is "the 1.1.6 binaries in tar/gz format"
 
+2018-10-24
+	Note that Jaxen 1.1.6 apparently has issues with JDK 9/10/11:
+	https://github.com/jaxen-xpath/jaxen/issues/12
 
 2013-05-05
 	use jaxen-1.1.6-bin.tar.gz

--- a/tools/OpenFst/README
+++ b/tools/OpenFst/README
@@ -10,12 +10,15 @@ Kleene, see kleene-lang/tools/README
 ***** lines below are notes, not instructions
 
 If the easy way is not possible or appropriate, you will 
-need to download openfst-1.3.3.tar.gz
+need to download openfst-1.4.1.tar.gz
 from
 	http://www.openfst.org
 to
 	kleene-lang/tools/OpenFst/
 
+
+2018-10-24
+	use openfst-1.4.1.tar.gz
 
 2013-05-05
 	use openfst-1.3.3.tar.gz

--- a/tools/dom4j/README
+++ b/tools/dom4j/README
@@ -12,7 +12,7 @@ to Kleene, see kleene-lang/tools/README
 If the easy way is not possible or appropriate, you will 
 need to download dom4j-1.6.1.tar.gz
 from
-	http://sourceforge.net/projects/dom4j/files/dom4j/1.6.1/
+	https://dom4j.github.io/
 to
 	kleene-lang/tools/dom4j/
 

--- a/tools/download.sh
+++ b/tools/download.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+base=$(dirname $0)
+
+# Apache Commons Lang
+COMMONS_LANG_BASENAME=commons-lang3-3.1
+curl -C - -o $base/Apache_Commons/KEYS http://www.apache.org/dist/commons/KEYS
+curl -C - -o $base/Apache_Commons/$COMMONS_LANG_BASENAME-bin.tar.gz https://archive.apache.org/dist/commons/lang/binaries/$COMMONS_LANG_BASENAME-bin.tar.gz
+curl -C - -o $base/Apache_Commons/$COMMONS_LANG_BASENAME-bin.tar.gz.asc https://archive.apache.org/dist/commons/lang/binaries/$COMMONS_LANG_BASENAME-bin.tar.gz.asc
+gpg --import $base/Apache_Commons/KEYS
+gpg --verify $base/Apache_Commons/$COMMONS_LANG_BASENAME-bin.tar.gz.asc \
+    || exit 1
+
+
+# ICU4C
+ICU4C=icu4c-54_1
+curl -C - -o $base/ICU4C/$ICU4C-src.tgz http://download.icu-project.org/files/icu4c/54.1/$ICU4C-src.tgz
+curl -C - -o $base/ICU4C/$ICU4C.md5 https://ssl.icu-project.org/files/icu4c/54.1/icu4c-src-54_1.md5
+pushd $base/ICU4C
+fgrep $ICU4C-src.tgz $ICU4C.md5 | md5sum -c - \
+    || exit 1
+popd
+
+
+# ICU4J
+ICU4J=icu4j-54_1_1
+curl -C - -o $base/ICU4J/$ICU4J.jar http://download.icu-project.org/files/icu4j/54.1.1/$ICU4J.jar
+curl -C - -o $base/ICU4J/$ICU4J.md5 https://ssl.icu-project.org/files/icu4j/54.1.1/icu4j-54_1_1.md5
+pushd $base/ICU4J
+fgrep $ICU4J.jar $ICU4J.md5 | md5sum -c - \
+    || exit 1
+popd
+
+# JavaCC
+JAVACC=javacc-5.0
+curl -C - -o $base/JavaCC/$JAVACC.tar.gz https://javacc.org/downloads/$JAVACC.tar.gz
+
+# Jaxen
+JAXEN=jaxen-1.1.6-bin
+curl -C - -o $base/Jaxen/$JAXEN.tar.gz http://www.cafeconleche.org/jaxen/dist/$JAXEN.tar.gz
+
+# OpenFst
+OPENFST=openfst-1.4.1
+curl -C - -o $base/OpenFst/$OPENFST.tar.gz http://www.openfst.org/twiki/pub/FST/FstDownload/$OPENFST.tar.gz
+
+# ROME
+ROME=rome-1.0
+curl -C - -o $base/ROME/$ROME.jar http://central.maven.org/maven2/rome/rome/1.0/$ROME.jar
+
+# dom4j
+DOM4J=dom4j-1.6.1
+curl -L -C - -o $base/dom4j/$DOM4J.tar.gz https://github.com/dom4j/dom4j/releases/download/dom4j_1_6_1/dom4j-1.6.1.tar.gz
+
+set -e
+make -C $base build-libraries


### PR DESCRIPTION
Some updates to the build instructions to (a) make the Makefile and README match, and (b) update the location of the third party downloads.